### PR TITLE
add single connection for pubsub (this is still not the best way but …

### DIFF
--- a/src/main/java/xyz/invisraidinq/redstone/RedstoneInitializer.java
+++ b/src/main/java/xyz/invisraidinq/redstone/RedstoneInitializer.java
@@ -1,6 +1,8 @@
 package xyz.invisraidinq.redstone;
 
 import java.util.Objects;
+
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Protocol;
 import xyz.invisraidinq.redstone.manager.connection.ConnectionManager;
@@ -12,7 +14,7 @@ public class RedstoneInitializer implements Redstone {
 
     private RedstoneInitializer(Builder builder) {
         final JedisPool jedisPool = this.initPool(builder);
-        this.connectionManager = new ConnectionManager(jedisPool, builder.channel);
+        this.connectionManager = new ConnectionManager(getSingleConnection(builder), jedisPool, builder.channel);
     }
 
     @Override
@@ -31,6 +33,18 @@ public class RedstoneInitializer implements Redstone {
             builder.authCredentials.getUsername(),
             builder.authCredentials.getPassword()
         );
+    }
+
+    private Jedis getSingleConnection(Builder builder){
+        Jedis jedis = new Jedis(builder.address, builder.port);
+        if(builder.authCredentials.getPassword() != null && builder.authCredentials.getUsername() != null){
+            jedis.auth(builder.authCredentials.getUsername(), builder.authCredentials.getPassword());
+        } else {
+            if(builder.authCredentials.getPassword() != null){
+                jedis.auth(builder.authCredentials.getPassword());
+            }
+        }
+        return jedis;
     }
 
     public static class Builder {
@@ -65,5 +79,6 @@ public class RedstoneInitializer implements Redstone {
 
             return new RedstoneInitializer(this);
         }
+
     }
 }


### PR DESCRIPTION
…at least now it is following the right procedure for connecting.

This adds a single connection for the pubsub, there is one last change that can be done to the pubsub library.

WIth the jedis pool etc, this does not handle reconnection, if you want to implement this logic its pretty much just change the thing to a Supplier<Jedis> and then do a loop while(true) on the thread and get the supplier for every .subscribe.